### PR TITLE
Fixed a typo in the README. covert.py -> covert.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ ./convert.rb *yaml
 Convert the provided YAML files, and save the resulting XML into a specified folder.
 
 ```bash
-$ ./convert.py -f some/other/folder 1.yaml 2.yaml
+$ ./convert.rb -f some/other/folder 1.yaml 2.yaml
 ```
 
 ### Validating XML


### PR DESCRIPTION
Was skimming through your README and I think I see a typo. I could be wrong so if I am just close this PR.
