### PR TITLE
Update for version 0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xml-converter
 
-A collection of small ruby scripts to convert [version 0.8](http://cricsheet.org/format/) [Cricsheet YAML data files](http://cricsheet.org/downloads/) into XML, and to allow validation of the XML against [the schema file (schema.xsd)](schema.xsd).
+A collection of small ruby scripts to convert [version 0.9](http://cricsheet.org/format/) [Cricsheet YAML data files](http://cricsheet.org/downloads/) into XML, and to allow validation of the XML against [the schema file (schema.xsd)](schema.xsd).
 
 These scripts are used to generate the XML data available in the [Cricsheet XML project](https://github.com/cricsheet/cricsheet-xml).
 

--- a/convert.rb
+++ b/convert.rb
@@ -7,7 +7,7 @@ require 'fileutils'
 require 'active_support/core_ext/hash/conversions'
 
 # A simple class to override default ruby YAML parsing of the over and
-# ball entry from the YAML. The 0.8 data has it as a simple float,
+# ball entry from the YAML. The 0.9 data has it as a simple float,
 # meaning that 0.10 (the 10th ball of the 1st over) incorrectly becomes
 # 0.1. This fixes the problem by simply returning the original string.
 class CricsheetScalarScanner < Psych::ScalarScanner
@@ -69,6 +69,12 @@ files.each_with_index do |file, index|
   yaml = YamlLoader.new(file).run
 
   data = yaml.slice('meta', 'info')
+  if data['info'].key?('supersubs')
+    data['info']['supersubs'] = data['info']['supersubs'].map do |team, player|
+      { 'team' => team, 'player' => player }
+    end
+  end
+
   data[:innings] = yaml['innings'].collect.with_index do |inning, inning_index|
     inning_name = inning.keys.first
     inning_data = inning[inning_name]

--- a/schema.xsd
+++ b/schema.xsd
@@ -68,6 +68,20 @@
                   </xs:sequence>
                 </xs:complexType>
               </xs:element>
+              <xs:element name="supersubs" minOccurs="0">
+                <xs:complexType>
+                  <xs:sequence>
+                    <xs:element name="supersub" minOccurs="1" maxOccurs="2">
+                      <xs:complexType>
+                        <xs:sequence>
+                          <xs:element type="xs:string" name="team"/>
+                          <xs:element type="xs:string" name="player"/>
+                        </xs:sequence>
+                      </xs:complexType>
+                    </xs:element>
+                  </xs:sequence>
+                </xs:complexType>
+              </xs:element>
               <xs:element name="teams">
                 <xs:complexType>
                   <xs:sequence>
@@ -132,6 +146,44 @@
                                   </xs:complexType>
                                 </xs:element>
                                 <xs:element type="xs:string" name="non_striker"/>
+                                <xs:element name="replacements" minOccurs="0">
+                                  <xs:complexType>
+                                    <xs:sequence>
+                                      <xs:element name="match" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:sequence>
+                                            <xs:element name="match" minOccurs="1" maxOccurs="unbounded">
+                                              <xs:complexType>
+                                                <xs:sequence>
+                                                  <xs:element type="xs:string" name="in"/>
+                                                  <xs:element type="xs:string" name="out"/>
+                                                  <xs:element type="xs:string" name="reason"/>
+                                                  <xs:element type="xs:string" name="team"/>
+                                                </xs:sequence>
+                                              </xs:complexType>
+                                            </xs:element>
+                                          </xs:sequence>
+                                        </xs:complexType>
+                                      </xs:element>
+                                      <xs:element name="role" minOccurs="0">
+                                        <xs:complexType>
+                                          <xs:sequence>
+                                            <xs:element name="role" minOccurs="1" maxOccurs="unbounded">
+                                              <xs:complexType>
+                                                <xs:sequence>
+                                                  <xs:element type="xs:string" name="in"/>
+                                                  <xs:element type="xs:string" name="out" minOccurs="0" maxOccurs="1"/>
+                                                  <xs:element type="xs:string" name="reason"/>
+                                                  <xs:element type="xs:string" name="role"/>
+                                                </xs:sequence>
+                                              </xs:complexType>
+                                            </xs:element>
+                                          </xs:sequence>
+                                        </xs:complexType>
+                                      </xs:element>
+                                    </xs:sequence>
+                                  </xs:complexType>
+                                </xs:element>
                                 <xs:element name="runs">
                                   <xs:complexType>
                                     <xs:sequence>
@@ -139,21 +191,6 @@
                                       <xs:element type="xs:int" name="extras"/>
                                       <xs:element type="xs:boolean" name="non_boundary" minOccurs="0"/>
                                       <xs:element type="xs:int" name="total"/>
-                                    </xs:sequence>
-                                  </xs:complexType>
-                                </xs:element>
-                                <xs:element name="supersub" minOccurs="0">
-                                  <xs:complexType>
-                                    <xs:sequence>
-                                      <xs:element name="supersub" minOccurs="1" maxOccurs="2">
-                                        <xs:complexType>
-                                          <xs:sequence>
-                                            <xs:element type="xs:string" name="in"/>
-                                            <xs:element type="xs:string" name="out"/>
-                                            <xs:element type="xs:string" name="team"/>
-                                          </xs:sequence>
-                                        </xs:complexType>
-                                      </xs:element>
                                     </xs:sequence>
                                   </xs:complexType>
                                 </xs:element>


### PR DESCRIPTION
Update the XML converter for the changes made in version 0.9 of the data format. Specifically we adjust the format of `supersubs`, as used in the YAML, to better suit XML. 

The `schema.xsd` file is also updated to reflect these changes, and now correctly validates both the new `supersubs` and `replacements` fields.